### PR TITLE
Adds tests for unnecessary whitespace on a blank <BsForm>

### DIFF
--- a/transforms/deprecated-attribute-arguments/__testfixtures__/form.input.hbs
+++ b/transforms/deprecated-attribute-arguments/__testfixtures__/form.input.hbs
@@ -9,3 +9,6 @@
     <f.element @foo="bar" @disabled={{true}} />
   </SomeOther>
 </BsForm>
+
+<BsForm as |f|>
+</BsForm>

--- a/transforms/deprecated-attribute-arguments/__testfixtures__/form.output.hbs
+++ b/transforms/deprecated-attribute-arguments/__testfixtures__/form.output.hbs
@@ -9,3 +9,6 @@
     <f.element @foo="bar" @disabled={{true}} />
   </SomeOther>
 </BsForm>
+
+<BsForm as |f|>
+</BsForm>


### PR DESCRIPTION
The codemod adds a unnecessary whitespace if `<BsForm>` has neither attributes nor named arguments:

```patch
- <BsForm as |form|>
+ <BsForm  as |form|>
```

This pull request provides a failing test to demonstrate the issue.