### PR TITLE
WIP: invalid indentation for multiline <Form::Element> (failing test)

### DIFF
--- a/transforms/deprecated-attribute-arguments/__testfixtures__/form.input.hbs
+++ b/transforms/deprecated-attribute-arguments/__testfixtures__/form.input.hbs
@@ -9,3 +9,10 @@
     <f.element @foo="bar" @disabled={{true}} />
   </SomeOther>
 </BsForm>
+
+<BsForm @model={{this}} as |f|>
+  <f.element
+    @property="foo"
+    @placeholder="foo"
+  />
+</BsForm>

--- a/transforms/deprecated-attribute-arguments/__testfixtures__/form.output.hbs
+++ b/transforms/deprecated-attribute-arguments/__testfixtures__/form.output.hbs
@@ -9,3 +9,12 @@
     <f.element @foo="bar" @disabled={{true}} />
   </SomeOther>
 </BsForm>
+
+<BsForm @model={{this}} as |f|>
+  <f.element
+    @property="foo"
+    as |el|
+  >
+    <el.control placeholder="foo" />
+  </f.element>
+</BsForm>


### PR DESCRIPTION
This adds a failing test that indentation is invalid (accordingly to default template linting) if `<Form::Element>` uses multiple lines for it's arguments and attributes on input:

Taking this input:

```hbs
<form.element
  @property="foo">
  @placeholder="foo">
/>
```

I would expect an output, which passes template linting. An example would be:

```hbs
<form.element
  @property="foo"
  as |el|
>
  <el.control placeholder="foo" />
</form.element>
```

But I see this one as demonstrated by failing test:

```hbs
<form.element
  @property="foo"
as |el|><el.control placeholder="foo" /></form.element>
```

Template linter throws errors due to indentation of `</form.element>` and `<el.control />`.